### PR TITLE
Add missing ActsAsStiLeafClass to AR models

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/cluster.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/cluster.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Ovirt::InfraManager::Cluster.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Redhat::InfraManager::Cluster < ManageIQ::Providers::Ovirt::InfraManager::Cluster
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/datacenter.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/datacenter.rb
@@ -1,3 +1,5 @@
+ManageIQ::Providers::Ovirt::InfraManager::Datacenter.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Redhat::InfraManager::Datacenter < ManageIQ::Providers::Ovirt::InfraManager::Datacenter
   def external_distributed_virtual_switches
     distributed_virtual_switches.select do |s|

--- a/app/models/manageiq/providers/redhat/infra_manager/distributed_virtual_switch.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/distributed_virtual_switch.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Ovirt::InfraManager::DistributedVirtualSwitch.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Redhat::InfraManager::DistributedVirtualSwitch < ManageIQ::Providers::Ovirt::InfraManager::DistributedVirtualSwitch
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/external_distributed_virtual_switch.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/external_distributed_virtual_switch.rb
@@ -1,3 +1,5 @@
+ManageIQ::Providers::Ovirt::InfraManager::ExternalDistributedVirtualSwitch.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Redhat::InfraManager::ExternalDistributedVirtualSwitch < ManageIQ::Providers::InfraManager::DistributedVirtualSwitch
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :external_distributed_virtual_switches, :class_name => "ManageIQ::Providers::Redhat::InfraManager"
 

--- a/app/models/manageiq/providers/redhat/infra_manager/folder.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/folder.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Ovirt::InfraManager::Folder.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Redhat::InfraManager::Folder < ManageIQ::Providers::InfraManager::Folder
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/futures_collector.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/futures_collector.rb
@@ -2,9 +2,9 @@ class ManageIQ::Providers::Redhat::InfraManager::FuturesCollector < ManageIQ::Pr
   DEFAULT_PARALLEL_PROCESSING_CAPACITY = ::Settings.ems_refresh.rhevm.pipeline * ::Settings.ems_refresh.rhevm.connections
 
   def initialize(args)
-      @keyed_futures_queue = []
-      @keyed_requests_queue = []
-      @parallel_processing_capacity = args[:batch_size] || DEFAULT_PARALLEL_PROCESSING_CAPACITY
-      @result_hash = {}
+    @keyed_futures_queue = []
+    @keyed_requests_queue = []
+    @parallel_processing_capacity = args[:batch_size] || DEFAULT_PARALLEL_PROCESSING_CAPACITY
+    @result_hash = {}
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Ovirt::InfraManager::Provision.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Redhat::InfraManager::Provision < ManageIQ::Providers::Ovirt::InfraManager::Provision
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/resource_pool.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/resource_pool.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Ovirt::InfraManager::ResourcePool.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Redhat::InfraManager::ResourcePool < ManageIQ::Providers::InfraManager::ResourcePool
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/storage.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/storage.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Ovirt::InfraManager::Storage.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Redhat::InfraManager::Storage < ManageIQ::Providers::InfraManager::Storage
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/template.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/template.rb
@@ -1,3 +1,5 @@
+ManageIQ::Providers::Ovirt::InfraManager::Template.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Redhat::InfraManager::Template < ManageIQ::Providers::Ovirt::InfraManager::Template
   include_concern 'ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared'
 

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -1,3 +1,5 @@
+ManageIQ::Providers::Ovirt::InfraManager::Vm.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Ovirt::InfraManager::Vm
   include_concern 'RemoteConsole'
   include_concern 'ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared'


### PR DESCRIPTION
There were a few models missing ActsAsStiLeafClass.

Cross-repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/596