### PR TITLE
We shouldn't require such a pessimistic version constraint here.

### DIFF
--- a/manageiq-providers-red_hat_virtualization.gemspec
+++ b/manageiq-providers-red_hat_virtualization.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ovirt-engine-sdk", "~>4.4.0"
-  spec.add_dependency "ovirt_metrics", "~>3.0.3"
+  spec.add_dependency "ovirt_metrics", "~>3.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
Same change as in the ovirt provider:
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/591

Note, we need this for rails 6.1 support as ovirt_metrics 3.1.0 allows rails 6.1