### PR TITLE
Replace deprecated method .parent for rails 6.1

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
@@ -11,7 +11,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   it "will perform a full refresh on v4.1" do
     EmsRefresh.refresh(@ems)
-    VCR.use_cassette("#{described_class.parent.name.underscore}/refresh/refresher_ovn_provider") do
+    VCR.use_cassette("#{described_class.module_parent.name.underscore}/refresh/refresher_ovn_provider") do
       Fog::OpenStack.instance_variable_set(:@version, nil)
       EmsRefresh.refresh(@ems.network_manager)
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_custom_attributes_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_custom_attributes_spec.rb
@@ -11,7 +11,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     @collector = ManageIQ::Providers::Redhat::Inventory::Collector
   end
 
-  CASSETTE_PATH = "#{described_class.parent.name.underscore}/refresh/refresher_ovn_provider".freeze
+  CASSETTE_PATH = "#{described_class.module_parent.name.underscore}/refresh/refresher_ovn_provider".freeze
 
   it "will fetch custom_attributes for full and targeted refresh" do
     EmsRefresh.refresh(@ems)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_lans_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_lans_spec.rb
@@ -12,7 +12,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   it "lans are not duplicated after refresh" do
     EmsRefresh.refresh(@ems)
 
-    VCR.use_cassette("#{described_class.parent.name.underscore}/refresh/refresher_ovn_provider") do
+    VCR.use_cassette("#{described_class.module_parent.name.underscore}/refresh/refresher_ovn_provider") do
       Fog::OpenStack.instance_variable_set(:@version, nil)
       EmsRefresh.refresh(@ems.network_manager)
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_multi_datacenter_network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_multi_datacenter_network_spec.rb
@@ -11,7 +11,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   it 'external networks belong to dc' do
     EmsRefresh.refresh(@ems)
-    VCR.use_cassette("#{described_class.parent.name.underscore}/refresh/refresher_multi_external_network_ovn_provider") do
+    VCR.use_cassette("#{described_class.module_parent.name.underscore}/refresh/refresher_multi_external_network_ovn_provider") do
       Fog::OpenStack.instance_variable_set(:@version, nil)
       EmsRefresh.refresh(@ems.network_manager)
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_network_ports_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_network_ports_spec.rb
@@ -11,7 +11,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   it 'Network port connected to vm guest_device' do
     EmsRefresh.refresh(@ems)
-    VCR.use_cassette("#{described_class.parent.name.underscore}/refresh/refresher_network_ports_ovn_provider") do
+    VCR.use_cassette("#{described_class.module_parent.name.underscore}/refresh/refresher_network_ports_ovn_provider") do
       Fog::OpenStack.instance_variable_set(:@version, nil)
       EmsRefresh.refresh(@ems.network_manager)
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_network_spec.rb
@@ -12,7 +12,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   it "will perform a full refresh" do
     EmsRefresh.refresh(@ems)
-    VCR.use_cassette("#{described_class.parent.name.underscore}/refresh/refresher_multi_external_network_ovn_provider") do
+    VCR.use_cassette("#{described_class.module_parent.name.underscore}/refresh/refresher_multi_external_network_ovn_provider") do
       Fog::OpenStack.instance_variable_set(:@version, nil)
       EmsRefresh.refresh(@ems.network_manager)
     end


### PR DESCRIPTION
Similar change was done in the ovirt provider from which this repository was
largely copied from: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/594