### PR TITLE
Ruby 3 support

### DIFF
--- a/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser/infra_manager.rb
@@ -123,7 +123,7 @@ class ManageIQ::Providers::Redhat::Inventory::Parser::InfraManager < ManageIQ::P
         :uid_ems          => vm.id,
         :connection_state => "connected",
         :vendor           => "redhat",
-        :name             => URI.decode(vm.name),
+        :name             => URI::DEFAULT_PARSER.unescape(vm.name),
         :location         => "#{vm.id}.ovf",
         :template         => template,
         :memory_limit     => extract_vm_memory_policy(vm, :max),

--- a/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/v4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/v4_spec.rb
@@ -277,8 +277,10 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4 do
         edit_spec = spec['networkAdapters'][:edit].first
         expect(nics_service).to receive(:nic_service).twice.with(edit_spec[:nic_id]).and_return(nic_service)
         expect(nic_service).to receive(:deactivate)
-        expect(nic_service).to receive(:update).with(:name         => edit_spec[:name],
-                                                     :vnic_profile => {:id => edit_spec[:vnic_profile_id]})
+        expect(nic_service).to receive(:update).with({
+                                                        :name         => edit_spec[:name],
+                                                        :vnic_profile => {:id => edit_spec[:vnic_profile_id]}
+                                                      })
         expect(nic_service).to receive(:activate)
 
         subject
@@ -435,7 +437,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4 do
       subject(:reconfigure_vm) { ems.vm_reconfigure(vm, :spec => spec) }
       context 'delete backing' do
         it 'sends a remove command to the appropriate disk attachment' do
-          expect(disk_attachment_service_1).to receive(:remove).with(:detach_only => false)
+          expect(disk_attachment_service_1).to receive(:remove).with({:detach_only => false})
           subject
         end
       end
@@ -443,7 +445,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4 do
       context 'detach without removing disk' do
         let(:delete_backing) { false }
         it 'sends a remove command to the appropriate disk attachment' do
-          expect(disk_attachment_service_1).to receive(:remove).with(:detach_only => true)
+          expect(disk_attachment_service_1).to receive(:remove).with({:detach_only => true})
           subject
         end
       end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
@@ -111,7 +111,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
           @task.options[:networks] = [{:network => vnic_profile_id}]
 
           expect(rhevm_vm).to receive(:nics).and_return([rhevm_nic1])
-          expect(nic1_service).to receive(:update).with(:name => "nic1", :vnic_profile => {:id => vnic_profile_id})
+          expect(nic1_service).to receive(:update).with({:name => "nic1", :vnic_profile => {:id => vnic_profile_id}})
 
           @task.configure_network_adapters
         end
@@ -120,7 +120,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
           @task.options[:networks] = [{:network => get_profile_description(vnic_profile_name, network.name)}]
 
           expect(rhevm_vm).to receive(:nics).and_return([rhevm_nic1])
-          expect(nic1_service).to receive(:update).with(:name => "nic1", :vnic_profile => {:id => vnic_profile_id})
+          expect(nic1_service).to receive(:update).with({:name => "nic1", :vnic_profile => {:id => vnic_profile_id}})
 
           @task.configure_network_adapters
         end
@@ -129,7 +129,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
           @task.options[:networks] = [{:network => '<Empty>'}]
 
           expect(rhevm_vm).to receive(:nics).and_return([rhevm_nic1])
-          expect(nic1_service).to receive(:update).with(:name => "nic1", :vnic_profile => {:id => nil})
+          expect(nic1_service).to receive(:update).with({:name => "nic1", :vnic_profile => {:id => nil}})
 
           @task.configure_network_adapters
         end
@@ -138,11 +138,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
           @task.options[:networks] = [{:network => vnic_profile_id, :mac_address => mac_address}]
 
           expect(rhevm_vm).to receive(:nics).and_return([rhevm_nic1])
-          expect(nic1_service).to receive(:update).with(
+          expect(nic1_service).to receive(:update).with({
             :name         => "nic1",
             :vnic_profile => {:id => vnic_profile_id},
             :mac          => ovirtSDK4_mac
-          )
+          })
 
           @task.configure_network_adapters
         end
@@ -153,11 +153,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
 
         expect(rhevm_vm).to receive(:nics).and_return([])
         expect(nics_service).to receive(:add)
-        expect(OvirtSDK4::Nic).to receive(:new).with(
+        expect(OvirtSDK4::Nic).to receive(:new).with({
           :name         => 'nic1',
           :vnic_profile => {:id => "vnic_profile_id"},
           :mac          => ovirtSDK4_mac
-        )
+        })
 
         @task.configure_network_adapters
       end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
@@ -87,7 +87,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine do
     def test_autostart_destination_with_use_cloud_init
       task.phase_context[:boot_with_cloud_init] = true
 
-      expect(rhevm_vm).to receive(:start).with(:use_cloud_init => an_instance_of(CustomAttribute))
+      expect(rhevm_vm).to receive(:start).with({:use_cloud_init => an_instance_of(CustomAttribute)})
 
       call_method
     end
@@ -95,7 +95,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine do
     def test_autostart_destination_without_use_cloud_init
       task.phase_context.delete(:boot_with_cloud_init)
 
-      expect(rhevm_vm).not_to receive(:start).with(:use_cloud_init => an_instance_of(CustomAttribute))
+      expect(rhevm_vm).not_to receive(:start).with({:use_cloud_init => an_instance_of(CustomAttribute)})
 
       call_method
     end
@@ -103,7 +103,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine do
     def test_autostart_destination_with_sysprep
       task.phase_context[:boot_with_sysprep] = true
 
-      expect(rhevm_vm).to receive(:start).with(:use_sysprep => an_instance_of(CustomAttribute))
+      expect(rhevm_vm).to receive(:start).with({:use_sysprep => an_instance_of(CustomAttribute)})
 
       call_method
     end
@@ -111,7 +111,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine do
     def test_autostart_destination_without_sysyprep
       task.phase_context.delete(:boot_with_sysprep)
 
-      expect(rhevm_vm).not_to receive(:start).with(:use_sysprep => an_instance_of(CustomAttribute))
+      expect(rhevm_vm).not_to receive(:start).with({:use_sysprep => an_instance_of(CustomAttribute)})
 
       call_method
     end


### PR DESCRIPTION
* Fix deprecated and now removed URI.decode (ruby 3)
* rspec-mocks 3.10.3 requires "with" to be explicit with hashes vs. kwargs