### PR TITLE
Update MiqQueue.count in Refresher spec

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher/refresher_4_async_graph_spec.rb
@@ -120,7 +120,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     expect(SystemService.count).to eq(0)
 
     expect(Relationship.count).to eq(20)
-    expect(MiqQueue.count).to eq(8)
+    expect(MiqQueue.count).to eq(7)
 
     expect(CloudNetwork.count).to eq(3)
     expect(CloudSubnet.count).to eq(3)


### PR DESCRIPTION
Now that we've removed the OVN network event catcher worker we have one less queue item when setting up the ems factories.

Introduced by: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/632
Same fix as: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/632#issuecomment-1450723087