### PR TITLE
Fix the Redhat NetworkManager in create dropdown

### DIFF
--- a/app/models/manageiq/providers/redhat/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/network_manager.rb
@@ -13,8 +13,6 @@ class ManageIQ::Providers::Redhat::NetworkManager < ManageIQ::Providers::Ovirt::
   include ManageIQ::Providers::Openstack::ManagerMixin
   include SupportsFeatureMixin
 
-  supports :create
-
   def self.ems_type
     @ems_type ||= "redhat_network".freeze
   end


### PR DESCRIPTION
The Redhat NetworkManager is a child of the InfraManager and thus should not be shown in the dropdown as an option when adding a new standalone network provider.