### PR TITLE
Fix targeted refresh duplicating external switches

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -25,6 +25,13 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::Ovirt::In
   require_nested  :DistributedVirtualSwitch
   require_nested  :ExternalDistributedVirtualSwitch
 
+  has_many :cloud_tenants, :foreign_key => :ems_id, :dependent => :destroy
+  has_many :vm_and_template_ems_custom_fields, :through => :vms_and_templates, :source => :ems_custom_attributes
+  has_many :external_distributed_virtual_switches, :dependent => :destroy, :foreign_key => :ems_id, :inverse_of => :ext_management_system
+  has_many :external_distributed_virtual_lans, -> { distinct }, :through => :external_distributed_virtual_switches, :source => :lans
+  has_many :iso_datastores, :dependent => :destroy, :foreign_key => :ems_id, :inverse_of => :ext_management_system
+  has_many :iso_images, :through => :storages
+
   has_one :network_manager,
           :foreign_key => :parent_ems_id,
           :class_name  => "ManageIQ::Providers::Redhat::NetworkManager",


### PR DESCRIPTION
Targeted refresh uses the associations to determine what records exist already in the database and will only create new records that aren't in that list, and, critically, will not delete records that aren't covered by the targeted scope.

Due to the `external_distributed_virtual_switches` and `external_distributed_virtual_lans` associations only existing in the `Ovirt::InfraManager` subclass, and `ActsAsStiLeafClass` not including subclasses, the associations were only looking for Ovirt classes and returning `[]` for ems.external_distributed_virtual_switches even though the switches did exist.

This caused a targeted refresh of a VM to duplicate switches and lans on every refresh, and a full refresh fixing the situation because it will delete what isn't in the current collection.