### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -1,30 +1,6 @@
 ManageIQ::Providers::Ovirt::InfraManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::Ovirt::InfraManager
-  require_nested  :Cluster
-  require_nested  :Datacenter
-  require_nested  :EventCatcher
-  require_nested  :EventParser
-  require_nested  :EventTargetParser
-  require_nested  :Folder
-  require_nested  :RefreshWorker
-  require_nested  :Refresher
-  require_nested  :ResourcePool
-  require_nested  :MetricsCapture
-  require_nested  :MetricsCollectorWorker
-  require_nested  :Host
-  require_nested  :Provision
-  require_nested  :ProvisionViaIso
-  require_nested  :ProvisionViaPxe
-  require_nested  :ProvisionWorkflow
-  require_nested  :Snapshot
-  require_nested  :Storage
-  require_nested  :IsoDatastore
-  require_nested  :Template
-  require_nested  :Vm
-  require_nested  :DistributedVirtualSwitch
-  require_nested  :ExternalDistributedVirtualSwitch
-
   has_many :cloud_tenants, :foreign_key => :ems_id, :dependent => :destroy
   has_many :vm_and_template_ems_custom_fields, :through => :vms_and_templates, :source => :ems_custom_attributes
   has_many :external_distributed_virtual_switches, :dependent => :destroy, :foreign_key => :ems_id, :inverse_of => :ext_management_system

--- a/app/models/manageiq/providers/redhat/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_catcher.rb
@@ -1,4 +1,3 @@
 class ManageIQ::Providers::Redhat::InfraManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
   #might need to set event catcher settings name here
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/metrics_collector_worker.rb
@@ -1,5 +1,4 @@
 class ManageIQ::Providers::Redhat::InfraManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
   self.default_queue_name = "redhat"
 
   def friendly_name

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
@@ -1,8 +1,8 @@
 module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
   extend ActiveSupport::Concern
 
-  include_concern 'Container'
-  include_concern 'Network'
+  include Container
+  include Network
 
   def attach_floppy_payload
     return unless content = customization_template_content

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_iso.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_iso.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso < ManageIQ::Providers::Redhat::InfraManager::Provision
-  include_concern 'Cloning'
-  include_concern 'Configuration'
-  include_concern 'StateMachine'
+  include Cloning
+  include Configuration
+  include StateMachine
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe < ManageIQ::Providers::Redhat::InfraManager::Provision
-  include_concern 'Cloning'
-  include_concern 'Configuration'
-  include_concern 'StateMachine'
+  include Cloning
+  include Configuration
+  include StateMachine
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Redhat::InfraManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/scanning.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/scanning.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Redhat::InfraManager::Scanning
-  require_nested :Job
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/template.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/template.rb
@@ -1,7 +1,7 @@
 ManageIQ::Providers::Ovirt::InfraManager::Template.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Redhat::InfraManager::Template < ManageIQ::Providers::Ovirt::InfraManager::Template
-  include_concern 'ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared'
+  include ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared
 
   supports :provisioning do
     if ext_management_system

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -1,8 +1,8 @@
 ManageIQ::Providers::Ovirt::InfraManager::Vm.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Ovirt::InfraManager::Vm
-  include_concern 'RemoteConsole'
-  include_concern 'ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared'
+  include RemoteConsole
+  include ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared
 
   supports :migrate do
     if blank? || orphaned? || archived?

--- a/app/models/manageiq/providers/redhat/infra_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_or_template_shared.rb
@@ -1,4 +1,4 @@
 module ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared
   extend ActiveSupport::Concern
-  include_concern 'Scanning'
+  include Scanning
 end

--- a/app/models/manageiq/providers/redhat/inventory.rb
+++ b/app/models/manageiq/providers/redhat/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Redhat::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   def self.default_manager_name
     "InfraManager"
   end

--- a/app/models/manageiq/providers/redhat/inventory/collector.rb
+++ b/app/models/manageiq/providers/redhat/inventory/collector.rb
@@ -1,6 +1,3 @@
 class ManageIQ::Providers::Redhat::Inventory::Collector < ManageIQ::Providers::Ovirt::Inventory::Collector
   # TODO: review the changes here and find common parts with ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4
-  require_nested :InfraManager
-  require_nested :NetworkManager
-  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/redhat/inventory/parser.rb
+++ b/app/models/manageiq/providers/redhat/inventory/parser.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Redhat::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :InfraManager
 end

--- a/app/models/manageiq/providers/redhat/inventory/persister.rb
+++ b/app/models/manageiq/providers/redhat/inventory/persister.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::Redhat::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :InfraManager
-  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/redhat/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/network_manager.rb
@@ -1,15 +1,6 @@
 ManageIQ::Providers::Ovirt::NetworkManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Redhat::NetworkManager < ManageIQ::Providers::Ovirt::NetworkManager
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :FloatingIp
-  require_nested :NetworkPort
-  require_nested :NetworkRouter
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :SecurityGroup
-
   include ManageIQ::Providers::Openstack::ManagerMixin
   include SupportsFeatureMixin
 

--- a/app/models/manageiq/providers/redhat/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/cloud_network.rb
@@ -1,6 +1,4 @@
 ManageIQ::Providers::Ovirt::NetworkManager::CloudNetwork.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork < ManageIQ::Providers::Ovirt::NetworkManager::CloudNetwork
-  require_nested :Private
-  require_nested :Public
 end

--- a/app/models/manageiq/providers/redhat/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/redhat/network_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_redhat_network
   end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854