### PR TITLE
drop unsupported_reason_add

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/host.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/host.rb
@@ -6,9 +6,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Host < ManageIQ::Providers::Ovi
   end
 
   supports :quick_stats do
-    unless ext_management_system.supports?(:quick_stats)
-      unsupported_reason_add(:quick_stats, 'RHV API version does not support quick_stats')
-    end
+    ext_management_system.unsupported_reason(:quick_stats)
   end
 
   def self.display_name(number = 1)

--- a/app/models/manageiq/providers/redhat/infra_manager/template.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/template.rb
@@ -5,9 +5,9 @@ class ManageIQ::Providers::Redhat::InfraManager::Template < ManageIQ::Providers:
 
   supports :provisioning do
     if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
+      ext_management_system.unsupported_reason(:provisioning)
     else
-      unsupported_reason_add(:provisioning, _('not connected to ems'))
+      _('not connected to ems')
     end
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -6,40 +6,39 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Ovirt
 
   supports :migrate do
     if blank? || orphaned? || archived?
-      unsupported_reason_add(:migrate, "Migrate operation in not supported.")
-    elsif !ext_management_system.supports?(:migrate)
-      unsupported_reason_add(:migrate, 'RHV API version does not support migrate')
+      "Migrate operation in not supported."
+    else
+      ext_management_system.unsupported_reason(:migrate)
     end
   end
 
   supports :reconfigure_disks do
     if storage.blank?
-      unsupported_reason_add(:reconfigure_disks, _('storage is missing'))
+      _('storage is missing')
     elsif ext_management_system.blank?
-      unsupported_reason_add(:reconfigure_disks, _('The virtual machine is not associated with a provider'))
-    elsif !ext_management_system.supports?(:reconfigure_disks)
-      unsupported_reason_add(:reconfigure_disks, _('The provider does not support reconfigure disks'))
+      _('The virtual machine is not associated with a provider')
+    else
+      ext_management_system.unsupported_reason(:reconfigure_disks)
     end
   end
 
   supports_not :reset
   supports :publish do
     if blank? || orphaned? || archived?
-      unsupported_reason_add(:publish, _('Publish operation in not supported'))
+      _('Publish operation in not supported')
     elsif ext_management_system.blank?
-      unsupported_reason_add(:publish, _('The virtual machine is not associated with a provider'))
-    elsif !ext_management_system.supports?(:publish)
-      unsupported_reason_add(:publish, _('This feature is not supported by the api version of the provider'))
+      _('The virtual machine is not associated with a provider')
     elsif power_state != "off"
-      unsupported_reason_add(:publish, _('The virtual machine must be down'))
+      _('The virtual machine must be down')
+    else
+      ext_management_system.unsupported_reason(:publish)
     end
   end
 
   supports :reconfigure_network_adapters
 
-  # supports :reconfigure_disksize
   supports :reconfigure_disksize do
-    unsupported_reason_add(:reconfigure_disksize, 'Cannot resize disks of a VM with snapshots') if snapshots.count > 1
+    'Cannot resize disks of a VM with snapshots' if snapshots.count > 1
   end
 
   def provider_object(connection = nil)


### PR DESCRIPTION
part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
