### PR TITLE
Delay load ovirtsdk4 client library

### DIFF
--- a/app/models/manageiq/providers/redhat/discovery.rb
+++ b/app/models/manageiq/providers/redhat/discovery.rb
@@ -1,5 +1,4 @@
 require 'manageiq/network_discovery/port'
-require 'ovirtsdk4'
 
 module ManageIQ
   module Providers
@@ -18,6 +17,8 @@ module ManageIQ
           private
 
           def ovirt_exists?(host, logger = nil)
+            require 'ovirtsdk4'
+
             opts = {
               :host => host,
               :log  => logger

--- a/app/models/manageiq/providers/redhat/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_parser.rb
@@ -82,6 +82,8 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParser
   end
 
   def self.ovirtobj_to_hash(obj)
+    require 'ovirtsdk4'
+
     obj.instance_variables.each_with_object({}) do |k, h|
       val = obj.instance_variable_get(k)
 

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb
@@ -1,4 +1,3 @@
-require 'ovirtsdk4'
 require 'yaml'
 
 module ManageIQ::Providers::Redhat::InfraManager::OvirtServices
@@ -11,6 +10,8 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices
     attr_reader :ext_management_system
 
     def initialize(args)
+      require 'ovirtsdk4'
+
       @ext_management_system = args[:ems]
     end
 


### PR DESCRIPTION
This is a openapi gem that eager loads all files currently so it's 10+ MB to load.

Related to https://github.com/ManageIQ/manageiq-providers-ovirt/pull/667

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
