### PR TITLE
upgrade ovirt to 4.6

### DIFF
--- a/manageiq-providers-red_hat_virtualization.gemspec
+++ b/manageiq-providers-red_hat_virtualization.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ovirt-engine-sdk", "~>4.4.0"
-  spec.add_dependency "ovirt_metrics", "~>3.2"
+  spec.add_dependency "manageiq-providers-ovirt"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
Updating gem because it fixes some issues with ruby 3.3 building

Gem released Feb 1, 2024