### PR TITLE
Delegate refresh_ems class method to parent infra manager

### DIFF
--- a/app/models/manageiq/providers/redhat/network_manager.rb
+++ b/app/models/manageiq/providers/redhat/network_manager.rb
@@ -4,6 +4,10 @@ class ManageIQ::Providers::Redhat::NetworkManager < ManageIQ::Providers::Ovirt::
   include ManageIQ::Providers::Openstack::ManagerMixin
   include SupportsFeatureMixin
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::Redhat::InfraManager
+  end
+
   def self.ems_type
     @ems_type ||= "redhat_network".freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,6 +57,7 @@
     :allow_targeted_refresh: true
   :redhat_network:
     :is_admin: false
+    :refresh_interval: 0
 :log:
   :level_rhevm: info
 :workers:


### PR DESCRIPTION
Reasoning here: https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

@miq-bot assign @agrare
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare